### PR TITLE
Merge release `0.25.1` back to `main`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,3 +27,19 @@ steps:
     key: lint
     command: make lint
 
+  - label: ":github: Release Build"
+    key: "gem-push"
+    if: build.tag != null
+    depends_on:
+     - build
+     - lint
+    command: |
+      docker run -v $(pwd):/app -w /app -e GOOS=darwin -e GOARCH=amd64 golang:1.20 go build -o packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_amd64
+      docker run -v $(pwd):/app -w /app -e GOOS=darwin -e GOARCH=arm64 golang:1.20 go build -o packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_arm64
+
+      zip -u packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_amd64 packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_amd64.zip
+      zip -u packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_arm64 packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_arm64.zip
+
+      docker run -v $(pwd):/app -w /app -e BUILDKITE_TAG -e GITHUB_TOKEN ruby:3.2.0 /bin/bash -c "bundle install && bundle exec ruby .buildkite/upload-artifacts.rb"
+    artifact_paths:
+      - "packer-plugin-hostmgr*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,8 +37,8 @@ steps:
       docker run -v $(pwd):/app -w /app -e GOOS=darwin -e GOARCH=amd64 golang:1.20 go build -o packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_amd64 -buildvcs=false
       docker run -v $(pwd):/app -w /app -e GOOS=darwin -e GOARCH=arm64 golang:1.20 go build -o packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_arm64 -buildvcs=false
 
-      zip -u packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_amd64 packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_amd64.zip
-      zip -u packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_arm64 packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_arm64.zip
+      zip "packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_amd64.zip" "packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_amd64"
+      zip "packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_arm64.zip" "packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_arm64"
 
       docker run -v $(pwd):/app -w /app -e BUILDKITE_TAG -e GITHUB_TOKEN ruby:3.2.0 /bin/bash -c "bundle install && bundle exec ruby .buildkite/upload-artifacts.rb"
     artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
 
   - label: ":golang-lint: Lint"
     key: lint
-    command: make lint
+    command: rm -rf .git && make lint
 
   - label: ":github: Release Build"
     key: "gem-push"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,7 @@ steps:
       -w /usr/src/plugin \
       -e GOOS={{ matrix.platform }} \
       -e GOARCH={{ matrix.arch }} \
-      golang:1.20 go build
+      golang:1.20 go build -buildvcs=false
     matrix:
       setup:
         platform:
@@ -34,8 +34,8 @@ steps:
      - build
      - lint
     command: |
-      docker run -v $(pwd):/app -w /app -e GOOS=darwin -e GOARCH=amd64 golang:1.20 go build -o packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_amd64
-      docker run -v $(pwd):/app -w /app -e GOOS=darwin -e GOARCH=arm64 golang:1.20 go build -o packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_arm64
+      docker run -v $(pwd):/app -w /app -e GOOS=darwin -e GOARCH=amd64 golang:1.20 go build -o packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_amd64 -buildvcs=false
+      docker run -v $(pwd):/app -w /app -e GOOS=darwin -e GOARCH=arm64 golang:1.20 go build -o packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_arm64 -buildvcs=false
 
       zip -u packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_amd64 packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_amd64.zip
       zip -u packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_arm64 packer-plugin-hostmgr_${BUILDKITE_TAG}_x5.0_darwin_arm64.zip

--- a/.buildkite/upload-artifacts.rb
+++ b/.buildkite/upload-artifacts.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+
+require 'octokit'
+require 'digest'
+
+repository = 'automattic/hostmgr-packer-plugin'
+
+abort "No GitHub Token present in environment" if ENV['GITHUB_TOKEN'].nil?
+
+## Find the tag
+tag_name = ENV['BUILDKITE_TAG']
+abort 'No `BUILDKITE_TAG` environment variable set' if ENV['BUILDKITE_TAG'].nil?
+
+## Find the release (creating it, if necessary)
+client = Octokit::Client.new(:access_token => ENV['GITHUB_TOKEN'])
+release = client.releases(repository).select { |release| tag_name == release[:tag_name] }.first
+release = client.create_release(repository, tag_name) if release.nil?
+
+HASHES_FILE = "packer-plugin-hostmgr_#{tag_name}_SHA256SUMS"
+
+[
+	"packer-plugin-hostmgr_#{tag_name}_x5.0_darwin_amd64.zip",
+	"packer-plugin-hostmgr_#{tag_name}_x5.0_darwin_arm64.zip",
+].map do |filename|
+
+	filepath = File.join(Dir.pwd, filename)
+	abort "No file found at `#{filepath}`" unless File.file?(filepath)
+
+	client.upload_asset(
+		release[:url],
+		filepath,
+		content_type: 'application/octet-stream'
+	)
+
+	sha256 = Digest::SHA256.file filepath
+	
+
+	File.write(HASHES_FILE, "#{sha256.hexdigest}  #{filename}\n", mode: "a")
+end
+
+client.upload_asset(
+	release[:url],
+	HASHES_FILE,
+	content_type: 'text/plain'
+)

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "octokit"
+gem "faraday-retry"
+gem "mime-types"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,33 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.5)
-      public_suffix (>= 2.0.2, < 6.0)
-    base64 (0.1.1)
-    faraday (2.7.11)
-      base64
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
-    faraday-retry (2.2.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    faraday (2.10.1)
+      faraday-net_http (>= 2.0, < 3.2)
+      logger
+    faraday-net_http (3.1.1)
+      net-http
+    faraday-retry (2.2.1)
       faraday (~> 2.0)
-    mime-types (3.5.1)
+    logger (1.6.0)
+    mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0808)
-    octokit (7.1.0)
+    mime-types-data (3.2024.0806)
+    net-http (0.4.1)
+      uri
+    octokit (9.1.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    public_suffix (5.0.3)
-    ruby2_keywords (0.0.5)
+    public_suffix (6.0.1)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
+    uri (0.13.0)
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
 
 DEPENDENCIES
   faraday-retry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,35 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.1.1)
+    faraday (2.7.11)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
+    faraday-retry (2.2.0)
+      faraday (~> 2.0)
+    mime-types (3.5.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0808)
+    octokit (7.1.0)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    public_suffix (5.0.3)
+    ruby2_keywords (0.0.5)
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+
+PLATFORMS
+  arm64-darwin-22
+
+DEPENDENCIES
+  faraday-retry
+  mime-types
+  octokit
+
+BUNDLED WITH
+   2.3.23

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ fmt:
 	docker run -v $(shell pwd):/usr/src/plugin -v $(shell pwd)/.build:/go -w /usr/src/plugin golang:1.20 go fmt
 
 lint:
-	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.54.2 /bin/bash -c "go mod vendor && golangci-lint run -v --modules-download-mode vendor --timeout=10m"
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.60.1 /bin/bash -c "go mod vendor && golangci-lint run -v --modules-download-mode vendor --timeout=10m"
 
 codegen:
 	docker run -v $(shell pwd):/usr/src/plugin -v $(shell pwd)/.build:/go -w /usr/src/plugin golang:1.20 go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@v0.4.0

--- a/example/macos-build-image.pkr.hcl
+++ b/example/macos-build-image.pkr.hcl
@@ -1,9 +1,9 @@
 packer {
   required_plugins {
-    #hostmgr = {
-    #  version = ">= 0.0.1"
-    #  source  = "github.com/Automattic/hostmgr"
-    #}
+    hostmgr = {
+     version = ">= 0.25.1"
+     source  = "github.com/Automattic/hostmgr"
+    }
   }
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -6,12 +6,12 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "0.0.1"
+	Version = "0.25.1"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this
 	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 
 	// PluginVersion is used by the plugin set to allow Packer to recognize
 	// what version this plugin is.


### PR DESCRIPTION
I got an error from Packer when trying to run `packer init` in the configuration for our macOS VM:

```console
* Continuing to next available version: binary reported version ("0.0.1-dev") is different from the expected "0.25.0", skipping
```
I suppose this error didn't show up before as perhaps this is a new validation from Packer.

So this PR basically fixes the binary version in `packer-plugin-hostmgr` and fixes the pipeline so that a new release can be built and published.

The previous release wasn't merged to `main`, so I branched off the [tag 0.25.0](https://github.com/Automattic/packer-plugin-hostmgr/commit/4826b0689455446bb813251fdd1e52c98e375044). I also suppose the previous version wasn't built on CI.

The diff between `0.25.0` and `0.25.1`: https://github.com/Automattic/packer-plugin-hostmgr/compare/v0.25.0...v0.25.1